### PR TITLE
[feat]: add net6.0 build target

### DIFF
--- a/MakeGenericAgain/MakeGenericAgain.csproj
+++ b/MakeGenericAgain/MakeGenericAgain.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>makeGenericAgain</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/MakeGenericAgain/NameReplacer.cs
+++ b/MakeGenericAgain/NameReplacer.cs
@@ -13,7 +13,7 @@ namespace MakeGenericAgain
             var toSplit = Regex.Replace(str, @"[^\w\.@-]", " ", RegexOptions.None, TimeSpan.FromSeconds(1.5)).Replace(".", " ");
             foreach (var word in toSplit.Split(" "))
             {
-                if (word.Contains("Of") && !word.StartsWith("Of") && !word.EndsWith("Of"))
+                if (word.Contains("Of") && !word.StartsWith("Of") && !word.EndsWith("Of") && !word.StartsWith("DateTime"))
                 {
                     var genericWordFor = GetGenericWordFor(word);
                     if (word != genericWordFor)


### PR DESCRIPTION
Hi there,

it would also be nice to have a net6.0 version of the nuget package, since they are not cross-compatible with net5.0 \\:

I sadly did not notice it until trying to build in a CI net6 sdk container:
```
  Launcher directory: /root/.nuget/packages/nswag.msbuild/13.15.10/tools/Net60
  Done.
  
  Duration: 00:00:03.0204280
  It was not possible to find any compatible framework version
  The framework 'Microsoft.NETCore.App', version '5.0.0' (x64) was not found.
    - The following frameworks were found:
        6.0.5 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```